### PR TITLE
Add exporter metrics for jvm uptime and open http connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Further Information
 | elasticsearch_jvm_memory_pool_max_bytes                               | counter   | 3           | JVM memory max by pool
 | elasticsearch_jvm_memory_pool_peak_used_bytes                         | counter   | 3           | JVM memory peak used by pool
 | elasticsearch_jvm_memory_pool_peak_max_bytes                          | counter   | 3           | JVM memory peak max by pool
+| elasticsearch_jvm_uptime_millis_total                                 | gauge     | 1           | JVM uptime in milliseconds
 | elasticsearch_os_cpu_percent                                          | gauge     | 1           | Percent CPU used by the OS
 | elasticsearch_os_load1                                                | gauge     | 1           | Shortterm load average
 | elasticsearch_os_load5                                                | gauge     | 1           | Midterm load average
@@ -199,6 +200,7 @@ Further Information
 | elasticsearch_transport_rx_size_bytes_total                           | counter   | 1           | Total number of bytes received
 | elasticsearch_transport_tx_packets_total                              | counter   | 1           | Count of packets sent
 | elasticsearch_transport_tx_size_bytes_total                           | counter   | 1           | Total number of bytes sent
+| elasticsearch_http_open_connections                                   | gauge     | 1           | Current number of open connections
 | elasticsearch_clusterinfo_last_retrieval_success_ts                   | gauge     | 1           | Timestamp of the last successful cluster info retrieval
 | elasticsearch_clusterinfo_up                                          | gauge     | 1           | Up metric for the cluster info collector
 | elasticsearch_clusterinfo_version_info                                | gauge     | 6           | Constant metric with ES version information as labels

--- a/collector/nodes.go
+++ b/collector/nodes.go
@@ -42,7 +42,7 @@ func getRoles(node NodeStatsNodeResponse) map[string]bool {
 			}
 		}
 	}
-	if len(node.HTTP) == 0 {
+	if node.HTTP == (NodeStatsHTTPResponse{}) {
 		roles["client"] = false
 	}
 	return roles
@@ -1351,6 +1351,20 @@ func NewNodes(logger log.Logger, client *http.Client, url *url.URL, all bool, no
 			{
 				Type: prometheus.GaugeValue,
 				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "jvm_uptime", "seconds_total"),
+					"JVM uptime in seconds",
+					defaultNodeLabels, nil,
+				),
+				Value: func(node NodeStatsNodeResponse) float64 {
+					return float64(node.JVM.Uptime) / 1000
+				},
+				Labels: func(cluster string, node NodeStatsNodeResponse) []string {
+					return defaultNodeLabelValues(cluster, node)
+				},
+			},
+			{
+				Type: prometheus.GaugeValue,
+				Desc: prometheus.NewDesc(
 					prometheus.BuildFQName(namespace, "process", "cpu_percent"),
 					"Percent CPU used by process",
 					defaultNodeLabels, nil,
@@ -1507,6 +1521,18 @@ func NewNodes(logger log.Logger, client *http.Client, url *url.URL, all bool, no
 				),
 				Value: func(node NodeStatsNodeResponse) float64 {
 					return float64(node.Transport.TxSize)
+				},
+				Labels: defaultNodeLabelValues,
+			},
+			{
+				Type: prometheus.GaugeValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "http", "open_connections"),
+					"Number of currently open HTTP connections",
+					defaultNodeLabels, nil,
+				),
+				Value: func(node NodeStatsNodeResponse) float64 {
+					return float64(node.HTTP.CurrentOpen)
 				},
 				Labels: defaultNodeLabelValues,
 			},

--- a/collector/nodes_response.go
+++ b/collector/nodes_response.go
@@ -24,7 +24,7 @@ type NodeStatsNodeResponse struct {
 	ThreadPool       map[string]NodeStatsThreadPoolPoolResponse `json:"thread_pool"`
 	JVM              NodeStatsJVMResponse                       `json:"jvm"`
 	Breakers         map[string]NodeStatsBreakersResponse       `json:"breakers"`
-	HTTP             map[string]int                             `json:"http"`
+	HTTP             NodeStatsHTTPResponse                      `json:"http"`
 	Transport        NodeStatsTransportResponse                 `json:"transport"`
 	Process          NodeStatsProcessResponse                   `json:"process"`
 }
@@ -42,6 +42,7 @@ type NodeStatsJVMResponse struct {
 	BufferPools map[string]NodeStatsJVMBufferPoolResponse `json:"buffer_pools"`
 	GC          NodeStatsJVMGCResponse                    `json:"gc"`
 	Mem         NodeStatsJVMMemResponse                   `json:"mem"`
+	Uptime      int64                                     `json:"uptime_in_millis"`
 }
 
 // NodeStatsJVMGCResponse defines node stats JVM garbage collector information structure


### PR DESCRIPTION
## Change summary

The original `elasticsearch_exporter` doesn't expose metrics for `jvm_uptime` and `current_open_http_connection`. 

This change adds metrics we use at Yelp for monitoring of our ES infrastructure. 

## Testing

Connected the exporter to a running ES node, the metrics are presented when curling `:9114/metrics` endpoint

JVM uptime in seconds

```
# HELP elasticsearch_jvm_uptime_seconds_total JVM uptime in seconds
# TYPE elasticsearch_jvm_uptime_seconds_total gauge
elasticsearch_jvm_uptime_seconds_total{cluster="testing720",es_client_node="true",es_data_node="true",es_ingest_node="false",es_master_node="false",host="REDACTED",name="REDACTED"} 319072.56
```

Current open HTTP connections

```
# HELP elasticsearch_http_open_connections Number of currently open HTTP connections
# TYPE elasticsearch_http_open_connections gauge
elasticsearch_http_open_connections{cluster="testing720",es_client_node="true",es_data_node="true",es_ingest_node="false",es_master_node="false",host="REDACTED",name="REDACTED"} 53
```